### PR TITLE
Bug 1123676: Add CAP_NET_ADMIN permission to bluetoothd.

### DIFF
--- a/scripts/init.bluetooth.rc
+++ b/scripts/init.bluetooth.rc
@@ -19,6 +19,6 @@
 service bluetoothd /system/bin/bluetoothd
     class main
     user bluetooth
-    group system
+    group system net_admin
     disabled
     oneshot


### PR DESCRIPTION
bluetoothd needs CAP_NET_ADMIN permission to switch on/off the Bluetooth function on Nexus-5.