### PR TITLE
Bug 1124760: Add net_bt_stack and bluetooth permission for enabling AVRCP in bluetoothd.

### DIFF
--- a/scripts/init.bluetooth.rc
+++ b/scripts/init.bluetooth.rc
@@ -19,6 +19,6 @@
 service bluetoothd /system/bin/bluetoothd
     class main
     user bluetooth
-    group system net_admin
+    group system net_admin net_bt_stack bluetooth
     disabled
     oneshot


### PR DESCRIPTION
As stated by :shawnjohnjr in bug 1124760, net_bt_stack permission is needed for nexus-5-l, and bluetooth permission is needed for flame-kk. Add these two permissions for bluetoothd.