### PR TITLE
Bug 1125719: Use empty strings for redials

### DIFF
--- a/src/bt-hf-io.c
+++ b/src/bt-hf-io.c
@@ -254,7 +254,8 @@ dial_call_cmd_cb(char* number)
   struct pdu_wbuf* wbuf;
   size_t len;
 
-  assert(number);
+  if (!number)
+    number = ""; /* Bug 1125719: number is NULL for redials */
 
   len = strlen(number) + 1;
 


### PR DESCRIPTION
Bluedroid uses NULL to signal redials of the last number. We cannot
process NULL, so we use an empty string instead.