### PR TITLE
Bug 1124556: Use correct type to unpack |channel| in |opcode_connect()|.

### DIFF
--- a/src/bt-sock-io.c
+++ b/src/bt-sock-io.c
@@ -134,7 +134,7 @@ opcode_connect(const struct pdu* cmd)
   bt_bdaddr_t bd_addr;
   uint8_t type;
   uint8_t uuid[16];
-  uint16_t channel;
+  int16_t channel;
   uint8_t flags;
   struct pdu_wbuf* wbuf;
   struct ancillary_data* data;


### PR DESCRIPTION
|channel| in |opcode_connect()| should be |int16_t| instead of |uint16_t|.