### PR TITLE
Bug 1129257: Use |int32_t| for |Channel| in Bluetooth Socket HAL. r=tzimmermann

### DIFF
--- a/src/bt-sock-io.c
+++ b/src/bt-sock-io.c
@@ -90,7 +90,7 @@ opcode_listen(const struct pdu* cmd)
   uint8_t type;
   int8_t service_name[256];
   uint8_t uuid[16];
-  uint16_t channel;
+  int32_t channel;
   uint8_t flags;
   struct pdu_wbuf* wbuf;
   struct ancillary_data* data;
@@ -99,7 +99,7 @@ opcode_listen(const struct pdu* cmd)
   assert(btsock_interface);
   assert(btsock_interface->listen);
 
-  if (read_pdu_at(cmd, 0, "CmmSC", &type,
+  if (read_pdu_at(cmd, 0, "CmmiC", &type,
                                    service_name, (size_t)sizeof(service_name),
                                    uuid, (size_t)sizeof(uuid),
                                    &channel, &flags) < 0)
@@ -134,7 +134,7 @@ opcode_connect(const struct pdu* cmd)
   bt_bdaddr_t bd_addr;
   uint8_t type;
   uint8_t uuid[16];
-  uint16_t channel;
+  int32_t channel;
   uint8_t flags;
   struct pdu_wbuf* wbuf;
   struct ancillary_data* data;
@@ -146,7 +146,7 @@ opcode_connect(const struct pdu* cmd)
   off = read_bt_bdaddr_t(cmd, 0, &bd_addr);
   if (off < 0)
     return BT_STATUS_PARM_INVALID;
-  if (read_pdu_at(cmd, off, "CmsC", &type, uuid, sizeof(uuid),
+  if (read_pdu_at(cmd, off, "CmiC", &type, uuid, sizeof(uuid),
                                     &channel, &flags) < 0)
     return BT_STATUS_PARM_INVALID;
 


### PR DESCRIPTION
Use |int32_t| for |Channel| in Bluetooth Socket HAL.