### PR TITLE
Bug 1131658: Test malloc's success by returned value instead of errno

### DIFF
--- a/src/bt-core-io.c
+++ b/src/bt-core-io.c
@@ -15,7 +15,6 @@
  */
 
 #include <assert.h>
-#include <errno.h>
 #include <fdio/task.h>
 #include <fdio/timer.h>
 #include <hardware/bluetooth.h>
@@ -147,6 +146,10 @@ align_properties(bt_property_t* properties, size_t num_properties,
   siz = sizeof(**aligned_properties) * num_properties;
 
   *aligned_properties = malloc(siz);
+  if (!*aligned_properties) {
+    ALOGE_ERRNO("malloc");
+    return NULL;
+  }
   memcpy(*aligned_properties, properties, siz);
 
   return *aligned_properties;
@@ -161,6 +164,8 @@ adapter_properties_cb(bt_status_t status, int num_properties,
 
   properties = align_properties(properties, num_properties,
                                 &aligned_properties);
+  if (!properties)
+    return;
 
   wbuf = create_pdu_wbuf(1 + /* status */
                          1 + /* number of properties */
@@ -202,6 +207,8 @@ remote_device_properties_cb(bt_status_t status,
 
   properties = align_properties(properties, num_properties,
                                 &aligned_properties);
+  if (!properties)
+    return;
 
   wbuf = create_pdu_wbuf(1 + /* status */
                          6 + /* address */
@@ -241,6 +248,8 @@ device_found_cb(int num_properties, bt_property_t* properties)
 
   properties = align_properties(properties, num_properties,
                                 &aligned_properties);
+  if (!properties)
+    return;
 
   wbuf = create_pdu_wbuf(1 + /* number of properties */
                          properties_length(num_properties, properties),

--- a/src/bt-pdubuf.c
+++ b/src/bt-pdubuf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014  Mozilla Foundation
+ * Copyright (C) 2014-2015  Mozilla Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,9 +76,8 @@ create_pdu_wbuf(unsigned long maxdatalen, unsigned long taillen,
 {
   struct pdu_wbuf* wbuf;
 
-  errno = 0;
   wbuf = malloc(sizeof(*wbuf) + maxdatalen + taillen);
-  if (errno) {
+  if (!wbuf) {
     ALOGE_ERRNO("malloc");
     goto err_malloc;
   }

--- a/src/bt-proto.c
+++ b/src/bt-proto.c
@@ -125,9 +125,8 @@ read_pdu_at_va(const struct pdu* pdu, unsigned long offset,
           return -1;
         }
         len = memdiff(pdu->data + offset, chr) + 1; /* include \0 byte */
-        errno = 0;
         dst = malloc(len);
-        if (errno) {
+        if (!dst) {
           ALOGE_ERRNO("malloc");
           return -1;
         }
@@ -177,9 +176,8 @@ read_bt_property_t(const struct pdu* pdu, unsigned long offset,
     return -1;
   offset = res;
 
-  errno = 0;
   val = malloc(len);
-  if (errno) {
+  if (!val) {
     ALOGE_ERRNO("malloc");
     return -1;
   }

--- a/src/bt-rc-io.c
+++ b/src/bt-rc-io.c
@@ -519,9 +519,8 @@ opcode_get_player_app_attr_text_rsp(const struct pdu* cmd)
   if (off < 0)
     return BT_STATUS_PARM_INVALID;
 
-  errno = 0;
   p_attrs = malloc(num_attr * sizeof(*p_attrs));
-  if (errno) {
+  if (!p_attrs) {
     ALOGE_ERRNO("malloc");
     return BT_STATUS_NOMEM;
   }
@@ -572,9 +571,8 @@ opcode_get_player_app_value_text_rsp(const struct pdu* cmd)
   if (off < 0)
     return BT_STATUS_PARM_INVALID;
 
-  errno = 0;
   p_attrs = malloc(num_attr * sizeof(*p_attrs));
-  if (errno) {
+  if (!p_attrs) {
     ALOGE_ERRNO("malloc");
     return BT_STATUS_NOMEM;
   }
@@ -625,9 +623,8 @@ opcode_get_element_attr_rsp(const struct pdu* cmd)
   if (off < 0)
     return BT_STATUS_PARM_INVALID;
 
-  errno = 0;
   p_attrs = malloc(num_attr * sizeof(*p_attrs));
-  if (errno) {
+  if (!p_attrs) {
     ALOGE_ERRNO("malloc");
     return BT_STATUS_NOMEM;
   }


### PR DESCRIPTION
We found an implementation of |malloc| that sets errno even if the
allocation succeeded. The current error checks return false positives
in this case.

This patch changes the code to test the returned pointer for a non-null
value instead.