### PR TITLE
Bug 1285831: fix unused parameter warning

### DIFF
--- a/src/bt-core-io.c
+++ b/src/bt-core-io.c
@@ -526,7 +526,7 @@ cleanup:
 #ifdef Q_BLUETOOTH
 static void
 pin_request_cb(bt_bdaddr_t* remote_bd_addr, bt_bdname_t* bd_name,
-               uint32_t cod, uint8_t secure)
+               uint32_t cod, uint8_t secure __attribute__((unused)))
 #else
 static void
 pin_request_cb(bt_bdaddr_t* remote_bd_addr, bt_bdname_t* bd_name,


### PR DESCRIPTION
Mark the "secure" parameter as unused to silence a warning preventing
the build because of the -Werror option.